### PR TITLE
Add options to tqdm.tqdm

### DIFF
--- a/parmap/parmap.py
+++ b/parmap/parmap.py
@@ -289,8 +289,8 @@ def map(function, iterable, *args, **kwargs):
        :param pm_processes: Number of processes to use in the pool. See
          :py:class:`multiprocessing.pool.Pool`
        :type pm_processes: int
-       :param pm_pbar: Show progress bar
-       :type pm_pbar: bool
+       :param pm_pbar: Show progress bar with optional information
+       :type pm_pbar: bool or dict
     """
     return _map_or_starmap(function, iterable, args, kwargs, "map")
 
@@ -309,8 +309,8 @@ def starmap(function, iterables, *args, **kwargs):
        :param pm_processes: Number of processes to use in the pool. See
                          :py:class:`multiprocessing.pool.Pool`
        :type pm_processes: int
-       :param pm_pbar: Show progress bar
-       :type pm_pbar: bool
+       :param pm_pbar: Show progress bar with optional information
+       :type pm_pbar: bool or dict
     """
     return _map_or_starmap(function, iterables, args, kwargs, "starmap")
 


### PR DESCRIPTION
Making `pm_pbar` to be a dictionary would be helpful when multiple progress bar is used (#28).

I tested the new feature by using the given [script](https://github.com/zeehio/parmap/blob/4db9f68b51ffc27e73bcc0d4435f61e84dea9911/parmap/parmap.py#L49-L62) in parmap.py as follows:

```python
from itertools import product
from parmap import parmap
from tqdm.auto import tqdm


def myfunction(x, y, a, b):
    return (x * y) ** (a * b)


def case1(listx, listy, a, b):
    listz = []
    num_executions = len(listx) * len(listy)
    with tqdm(desc="Case 1", total=num_executions, unit="execution") as pbar:
        for x in listx:
            for y in listy:
                listz.append(myfunction(x, y, a, b))
                pbar.update(1)
    return listz


def case2(listx, listy, a, b):
    tqdm_options={
        "desc": "Case 2",
        "unit": "execution",
    }
    listxy = list(product(listx, listy))  # 'itertools.product' has no len()
    listz = parmap.starmap(myfunction, listxy, a, b, pm_pbar=tqdm_options)
    return listz


if __name__ == "__main__":
    listx = [1, 2, 3, 4, 5, 6]
    listy = [2, 3, 4, 5, 6, 7]
    a = 3.14
    b = 42

    listz1 = case1(listx, listy, a, b)
    listz2 = case2(listx, listy, a, b)

    assert listz1 == listz2
```

I think it works 😅