### PR TITLE
Fix silent error swallowing and resource cleanup bugs from code review

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,21 @@
 parmap (1.7.0.9000)
 
-  * No changes yet
+  [Bug fixes]
+
+  * Stop silently swallowing all exceptions (including KeyboardInterrupt) in
+    the progress bar polling loop; only AttributeError is caught now.
+  * Avoid a ZeroDivisionError in the default chunksize calculation when the
+    pool has no workers.
+  * Ensure the pool is joined for cleanup even when an async result's get()
+    raises the worker's exception, instead of only on the happy path.
+
+  [Maintenance]
+
+  * Replace `isinstance(x, typing.Callable)` with `callable(x)`.
+  * Remove long-dead commented-out draft of an `imap`/`istarmap` API.
+  * Fix stale variable names in `_func_star_many`'s docstring.
+  * Document the Windows/macOS "spawn" `if __name__ == "__main__":` guard
+    requirement in the README.
 
  -- Sergio Oller <sergioller@gmail.com>  Sat, 09 Sep 2023 20:05:00 +0200
 

--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,16 @@ Installation:
 Usage:
 ------
 
+.. note::
+  ``parmap`` uses ``multiprocessing.Pool`` under the hood. On Windows (and on
+  macOS with the default "spawn" start method), any script that calls
+  ``parmap.map``/``parmap.starmap`` at import time must guard that code with
+  ``if __name__ == "__main__":``, otherwise each worker process will try to
+  re-import and re-run the script, causing a ``RuntimeError`` or runaway
+  process spawning. See the `multiprocessing programming guidelines
+  <https://docs.python.org/3/library/multiprocessing.html#the-spawn-and-forkserver-start-methods>`__
+  for details.
+
 Here are some examples with some unparallelized code parallelized with
 parmap:
 

--- a/parmap/parmap.py
+++ b/parmap/parmap.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#   Copyright 2014-2022 Sergio Oller <sergioller@gmail.com>
+#   Copyright 2014-2026 Sergio Oller <sergioller@gmail.com>
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ def _func_star_single(func_item_args):
     item = func_item_args[1]
     args = func_item_args[2]
     kwargs = func_item_args[3]
-    return func(item,args[0],args[1],..., **kwargs)
+    return func(item, args[0], args[1], ..., **kwargs)
     """
     return func_item_args[0](
         *[func_item_args[1]] + func_item_args[2], **func_item_args[3]
@@ -98,10 +98,10 @@ def _func_star_single(func_item_args):
 
 def _func_star_many(func_items_args):
     """Equivalent to:
-    func = func_item_args[0]
-    items = func_item_args[1]
-    args = func_item_args[2:]
-    kwargs = func_item_args[3]
+    func = func_items_args[0]
+    items = func_items_args[1]
+    args = func_items_args[2]
+    kwargs = func_items_args[3]
     return func(items[0], items[1], ..., args[0], args[1], ..., **kwargs)
     """
     return func_items_args[0](
@@ -139,7 +139,9 @@ def _do_pbar(async_result, num_tasks, chunksize, refresh_time, pbar_wrapper):
                 remaining_now = async_result._number_left * chunksize
                 done_now = remaining - remaining_now
                 remaining = remaining_now
-            except:
+            except AttributeError:
+                # _number_left is a private multiprocessing attribute that
+                # may not be present on all AsyncResult-like objects.
                 break
             if done_now > 0:
                 pbar.update(done_now)
@@ -150,7 +152,10 @@ def _get_default_chunksize(chunksize, pool, num_tasks):
     # default from multiprocessing
     # https://github.com/python/cpython/blob/master/Lib/multiprocessing/pool.py
     if chunksize is None:
-        chunksize, extra = divmod(num_tasks, len(pool._pool) * 4)
+        num_workers = len(pool._pool)
+        if num_workers == 0:
+            return 1
+        chunksize, extra = divmod(num_tasks, num_workers * 4)
         if extra:
             chunksize += 1
     return chunksize
@@ -165,7 +170,7 @@ def _prepare_pbar_wrapper(progress):
     elif isinstance(progress, dict) and HAVE_TQDM:
         has_pbar = True
         wrapper = partial(tqdm.tqdm, **progress)
-    elif isinstance(progress, T.Callable):
+    elif callable(progress):
         has_pbar = True
         wrapper = progress
     return (has_pbar, wrapper)
@@ -409,10 +414,15 @@ class _ParallelAsyncResult(AsyncResult):
         return self._result._number_left
 
     def get(self, timeout=None):
-        values = self._result.get(timeout)
-        if self.ready():
-            self.join()
-        return values
+        try:
+            return self._result.get(timeout)
+        finally:
+            # Only join if the underlying result is actually done: a
+            # TimeoutError means the task is still running, and joining
+            # would block until it finishes instead of letting the
+            # caller retry get() later.
+            if self._result.ready():
+                self.join()
 
     def wait(self, timeout=None):
         return self._result.wait(timeout)
@@ -538,40 +548,3 @@ def starmap_async(function, iterables, *args, **kwargs):
     :type pm_processes: int
     """
     return _map_or_starmap_async(function, iterables, args, kwargs, "starmap")
-
-
-# Needs testing, but it might work as it is:
-
-# def _serial_imap_or_istarmap(function, iterable, args,
-#                              kwargs, map_or_starmap):
-#    if map_or_starmap == "map":
-#        output = (function(*([item] + list(args)), **kwargs)
-#                  for item in iterable)
-#    elif map_or_starmap == "starmap":
-#        output = (function(*(list(item) + list(args)), **kwargs)
-#                  for item in iterable)
-#    else:
-#        raise AssertionError("Internal parmap error: " +
-#                             "Invalid map_or_starmap. This should not happen")
-#    return output
-
-
-# def imap(function, iterable, *args, **kwargs):
-#    chunksize = kwargs.pop("pm_chunksize", 1)
-#    parallel, pool, close_pool = _create_pool(kwargs)
-#    # Map:
-#    if parallel:
-#        func_star = _get_helper_func("map")
-#        try:
-#            output = pool.imap(func_star,
-#                               zip(repeat(function), iterable,
-#                                   repeat(list(args)), repeat(kwargs)),
-#                               chunksize)
-#        finally:
-#            if close_pool:
-#                pool.close()
-#                pool.join()
-#    else:
-#        output = _serial_imap_or_istarmap(function, iterable, args, kwargs,
-#                                          map_or_starmap)
-#    return output

--- a/test_parmap.py
+++ b/test_parmap.py
@@ -26,6 +26,13 @@ def _identity(*x):
     return x
 
 
+def _boom(x):
+    """Dummy function that raises for one specific input"""
+    if x == 2:
+        raise ValueError("boom")
+    return x
+
+
 _DEFAULT_B = 1
 
 
@@ -182,6 +189,63 @@ class TestParmap(unittest.TestCase):
             warnings.simplefilter("always")
             parmap.map(range, [1, 2], pm_processes=-3)
             self.assertTrue(len(w) > 0)
+
+    def test_map_worker_exception_propagates(self):
+        with self.assertRaises(ValueError):
+            parmap.map(_boom, range(4), pm_parallel=True)
+        with self.assertRaises(ValueError):
+            parmap.map(_boom, range(4), pm_parallel=False)
+
+    def test_map_async_cleans_up_pool_on_worker_error(self):
+        with parmap.map_async(_boom, range(4), pm_processes=2) as result:
+            with self.assertRaises(ValueError):
+                result.get()
+            # The pool must be joined for cleanup even though get() raised.
+            self.assertIsNone(result._pool)
+
+    def test_do_pbar_does_not_swallow_unexpected_errors(self):
+        from parmap.parmap import _do_pbar
+
+        class _NullPbar:
+            def __init__(self, total=None):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc_info):
+                return False
+
+            def update(self, n=1):
+                pass
+
+        class _FakeAsyncResult:
+            def ready(self):
+                return False
+
+            @property
+            def _number_left(self):
+                raise RuntimeError("unexpected failure, not an AttributeError")
+
+            def wait(self, timeout=None):
+                pass
+
+        with self.assertRaises(RuntimeError):
+            _do_pbar(
+                _FakeAsyncResult(),
+                num_tasks=1,
+                chunksize=1,
+                refresh_time=0,
+                pbar_wrapper=_NullPbar,
+            )
+
+    def test_get_default_chunksize_zero_workers(self):
+        from parmap.parmap import _get_default_chunksize
+
+        class _FakePool:
+            _pool = []
+
+        self.assertEqual(_get_default_chunksize(None, _FakePool(), 10), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Stop catching bare exceptions in the progress bar polling loop
  (was hiding KeyboardInterrupt and unrelated bugs); catch only
  AttributeError, which is what the private _number_left access
  guards against.
- Guard the default chunksize calculation against ZeroDivisionError
  when a pool has no workers.
- Fix _ParallelAsyncResult.get() so the pool is joined for cleanup
  even when the wrapped call raises the worker's exception, while
  still not blocking on a plain TimeoutError.
- Replace isinstance(x, typing.Callable) with callable(x).
- Remove long-dead commented-out imap/istarmap draft code.
- Fix stale variable names in _func_star_many's docstring.
- Document the Windows/macOS "spawn" __name__ == "__main__" guard
  requirement in the README.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CCVXqX6vkWNBxHJ85zgAgz