### PR TITLE
Fix silent error-handling bugs, add regression tests, extend CI to Python 3.12/3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -24,12 +24,12 @@ jobs:
     - name: Test with tox
       run: tox
     - name: Upload coverage.xml
-      if: ${{ matrix.python-version == '3.11' }}
+      if: ${{ matrix.python-version == '3.13' }}
       uses: actions/upload-artifact@v3
       with:
         name: tox-gh-actions-coverage
         path: coverage.xml
         if-no-files-found: error
     - name: Upload coverage.xml to codecov
-      if: ${{ matrix.python-version == '3.11' }}
+      if: ${{ matrix.python-version == '3.13' }}
       uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -25,11 +25,13 @@ jobs:
       run: tox
     - name: Upload coverage.xml
       if: ${{ matrix.python-version == '3.13' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v7
       with:
         name: tox-gh-actions-coverage
         path: coverage.xml
         if-no-files-found: error
     - name: Upload coverage.xml to codecov
       if: ${{ matrix.python-version == '3.13' }}
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v7
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,8 @@ parmap (1.7.0.9000)
   * Fix stale variable names in `_func_star_many`'s docstring.
   * Document the Windows/macOS "spawn" `if __name__ == "__main__":` guard
     requirement in the README.
+  * Test and add support for Python 3.12 and 3.13 (CI matrix, tox envlist
+    and classifiers).
 
  -- Sergio Oller <sergioller@gmail.com>  Sat, 09 Sep 2023 20:05:00 +0200
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 [project.urls]
@@ -47,14 +49,16 @@ include = [
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py38, py39, py310, py311, mypy, coverage
+envlist = py38, py39, py310, py311, py312, py313, mypy, coverage
 
 [gh-actions]
 python =
     3.8: py38
     3.9: py39
     3.10: py310
-    3.11: py311, mypy, coverage
+    3.11: py311
+    3.12: py312
+    3.13: py313, mypy, coverage
 
 [testenv:coverage]
 deps =


### PR DESCRIPTION
## Summary

Follow-up from a critical code review of `parmap/parmap.py`:

- Stop swallowing all exceptions (including `KeyboardInterrupt`) in the progress-bar polling loop; catch only `AttributeError`, which is what the private `_number_left` attribute access is actually guarding against.
- Avoid a `ZeroDivisionError` in the default chunksize calculation when a pool has no workers.
- Fix `_ParallelAsyncResult.get()` so the pool is joined for cleanup even when the wrapped call raises the worker's exception, without blocking on a plain `TimeoutError`.
- Replace `isinstance(x, typing.Callable)` with `callable(x)`.
- Remove long-dead commented-out `imap`/`istarmap` draft code.
- Fix stale variable names in `_func_star_many`'s docstring.
- Document the Windows/macOS "spawn" `if __name__ == "__main__":` guard requirement in the README.
- Add regression tests for each of the above bug fixes (verified each new test fails against the pre-fix code).
- Extend CI matrix, tox envlist, and packaging classifiers to Python 3.12 and 3.13 — verified the full test suite (16 tests) and `mypy` pass cleanly on 3.8 through 3.13 in isolated venvs before extending support.

## Test plan

- [x] `python3 test_parmap.py` passes (16/16) on Python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13
- [x] `mypy -p parmap` passes on 3.13
- [x] Each new regression test manually confirmed to fail against the pre-fix code and pass against the fix


---
_Generated by [Claude Code](https://claude.ai/code/session_01CCVXqX6vkWNBxHJ85zgAgz)_